### PR TITLE
Don't cache errors

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -159,7 +159,9 @@ async function graphqlHandler(request, env, ctx) {
         result.warnings.push(...context.warnings);
     }
 
-    if (specialCache === 'application/json') {
+    if (result.errors?.some(err => err.message === 'Unexpected error.')) {
+        ttl = 0;
+    } else if (specialCache === 'application/json') {
         if (!result.warnings) {
             result = Object.assign({warnings: []}, result);
         }

--- a/plugins/plugin-use-cache-machine.mjs
+++ b/plugins/plugin-use-cache-machine.mjs
@@ -83,7 +83,9 @@ export default function useCacheMachine(env) {
             let ttl = request.data?.getRequestTtl(request.requestId) ?? 60 * 5;
 
             const sCache = specialCache(request);
-            if (sCache === 'application/json') {
+            if (result.errors?.some(err => err.message === 'Unexpected error.')) {
+                ttl = 0;
+            } else if (sCache === 'application/json') {
                 if (!result.warnings) {
                     result = Object.assign({warnings: []}, result);
                 }


### PR DESCRIPTION
When the graphql response contains an unexpected error, don't cache that response.